### PR TITLE
Redirects status messages to stderr only

### DIFF
--- a/.semver.yaml
+++ b/.semver.yaml
@@ -1,5 +1,4 @@
 alpha: 0
 beta: 0
 rc: 0
-release: v0.3.0
-
+release: v0.4.1

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -44,8 +43,8 @@ func main() {
 	mcpServer.RegisterDefaultHandlers()
 
 	// Start the server with stdio protocol
-	fmt.Println("MBTA MCP Server started successfully")
-	fmt.Println("Using stdio protocol - input and output are on stdin/stdout")
+	log.Println("MBTA MCP Server started successfully")
+	log.Println("Using stdio protocol - input and output are on stdin/stdout")
 	if err := mcpServer.Start(); err != nil {
 		log.Fatalf("Error running MCP server: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
TL;DR
-----
Ensures MCP server status messages go to stderr instead of stdout for proper client integration.

Details
-------
Modifies the server startup code to direct status messages to stderr rather than stdout by changing fmt.Println calls to log.Println. This separation prevents status information from interfering with the MCP protocol communication, which should have exclusive access to stdout.

The change allows MCP clients to properly parse protocol messages without getting confused by status text that appears in the same output stream.

🤖 Generated with [Claude Code](https://claude.ai/code)