### PR TITLE
Adds resilience to Makefile for missing .env file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include .env
+-include .env
 
 BINARY_NAME=mbta-mcp-server
 GIT_SHORT_SHA=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")


### PR DESCRIPTION
TL;DR
-----
Prevents Makefile failures when .env file is missing.

Details
-------
Modifies the .env include directive with a dash prefix, instructing Make to ignore errors during file inclusion. Ensures build processes continue even when no .env file exists in the project directory.

🤖 Generated with [Claude Code](https://claude.ai/code)